### PR TITLE
Added settings.xml copy over 7TH Heaven directory

### DIFF
--- a/7HFix.sh
+++ b/7HFix.sh
@@ -114,14 +114,9 @@ echo "Done!"
 
 echo
 echo "Setting up 7TH Heaven..."
-RESET_SETTINGS=0
-read -rp "Do you want to reset 7TH settings? [y/N] "
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-  RESET_SETTINGS=1
-  mkdir -p "$FULL_PATH/7thWorkshop/"
-  cp -f ./settings.xml "$FULL_PATH/7thWorkshop/"
-  echo "Done!"
-fi
+mkdir -p "$FULL_PATH/7thWorkshop/"
+cp -f ./settings.xml "$FULL_PATH/7thWorkshop/"
+echo "Done!"
 
 echo
 echo "Altering Steam Shortcut"
@@ -141,5 +136,5 @@ protontricks $APP_ID dinput
 echo
 clear
 echo "*******  RESTART STEAM BEFORE LAUNCHING THE GAME  *******"
-[ $RESET_SETTINGS == 1 ] && echo "*******  IMPORTANT ON FIRST OPENING: Re-select FF7 Exe Path with the same one selected  *******"
+echo "*******  IMPORTANT ON FIRST OPENING: Re-select FF7 Exe Path with the same one selected  *******"
 echo "7th Heaven Canary has been successfully installed!"

--- a/7HFix.sh
+++ b/7HFix.sh
@@ -108,21 +108,38 @@ echo "44000000" > "$WINEPATH/drive_c/.windows-serial"
 [ -d "$WINEPATH/drive_c/FF7" ] && rm -r "$WINEPATH/drive_c/FF7"
 cp -Rfp "$FF7_LOCATION" "$WINEPATH/drive_c/FF7"
 mkdir -p $WINEPATH/drive_c/FF7/mods/{7thHeaven,textures}
-cp dxvk.conf "$WINEPATH/drive_c/$DEFAULT_7TH_HEAVEN_DIRECTORY"
+FULL_PATH="$WINEPATH/drive_c/$DEFAULT_7TH_HEAVEN_DIRECTORY"
+cp dxvk.conf "$FULL_PATH"
+echo "Done!"
+
+echo
+echo "Setting up 7TH Heaven..."
+RESET_SETTINGS=0
+read -rp "Do you want to reset 7TH settings? [y/N] "
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  RESET_SETTINGS=1
+  mkdir -p "$FULL_PATH/7thWorkshop/"
+  cp -f ./settings.xml "$FULL_PATH/7thWorkshop/"
+  echo "Done!"
+fi
+
 echo
 echo "Altering Steam Shortcut"
-FULL_PATH="$WINEPATH/drive_c/$DEFAULT_7TH_HEAVEN_DIRECTORY"
 SHORTCUTSFILE=$(ls -td ${HOME}/.steam/steam/userdata/* | head -1)/config/shortcuts.vdf
 sed -i "s:$(pwd)/${SEVENHEAVEN}:${FULL_PATH}/7th Heaven.exe:" $SHORTCUTSFILE
 sed -i "s:$(pwd):${FULL_PATH}:" $SHORTCUTSFILE
 echo "Done!"
+
 echo
 echo "Removing & installing dinput..."
-echo
+
 [ -f "$WINEPATH/drive_c/windows/syswow64/dinput.dll" ] && rm "$WINEPATH/drive_c/windows/syswow64/dinput.dll"
+
 echo
 protontricks $APP_ID dinput
+
 echo
 clear
 echo "*******  RESTART STEAM BEFORE LAUNCHING THE GAME  *******"
+[ $RESET_SETTINGS == 1 ] && echo "*******  IMPORTANT ON FIRST OPENING: Re-select FF7 Exe Path with the same one selected  *******"
 echo "7th Heaven Canary has been successfully installed!"

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Steps:
 * Type `chmod +x 7HFix.sh`
 * Run the script with `./7HFix.sh`
 * Follow the steps and enjoy!
+* 

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <AppLanguage>en</AppLanguage>
+  <SubscribedUrls>
+    <string>iros://Url/https$github.com/tsunamods-codes/7th-Heaven-Catalogs/releases/download/canary/qhimm.xml</string>
+    <string>iros://Url/https$github.com/tsunamods-codes/7th-Heaven-Catalogs/releases/download/canary/sega.xml</string>
+  </SubscribedUrls>
+  <ExtraFolders>
+    <string>ambient</string>
+    <string>direct</string>
+    <string>lighting</string>
+    <string>music</string>
+    <string>sfx</string>
+    <string>time</string>
+    <string>voice</string>
+    <string>widescreen</string>
+  </ExtraFolders>
+  <Subscriptions>
+    <Subscription>
+      <FailureCount>0</FailureCount>
+      <Url>iros://Url/https$github.com/tsunamods-codes/7th-Heaven-Catalogs/releases/download/canary/qhimm.xml</Url>
+      <Name>Qhimm Catalog</Name>
+    </Subscription>
+    <Subscription>
+      <FailureCount>0</FailureCount>
+      <Url>iros://Url/https$github.com/tsunamods-codes/7th-Heaven-Catalogs/releases/download/canary/sega.xml</Url>
+      <Name>Sega Catalog</Name>
+    </Subscription>
+  </Subscriptions>
+  <LibraryLocation>C:\FF7\mods\7th Heaven</LibraryLocation>
+  <FF7Exe>C:\FF7\ff7_en.exe</FF7Exe>
+  <AaliFolder>C:\FF7\mods\Textures</AaliFolder>
+  <MovieFolder>C:\FF7\data\movies</MovieFolder>
+  <FFNxUpdateChannel>Canary</FFNxUpdateChannel>
+  <AppUpdateChannel>Canary</AppUpdateChannel>
+  <Options>
+    <GeneralOptions>AutoActiveNewMods</GeneralOptions>
+    <GeneralOptions>AutoImportMods</GeneralOptions>
+    <GeneralOptions>CheckForUpdates</GeneralOptions>
+    <GeneralOptions>OpenIrosLinksWith7H</GeneralOptions>
+    <GeneralOptions>OpenModFilesWith7H</GeneralOptions>
+    <GeneralOptions>WarnAboutModCode</GeneralOptions>
+  </Options>
+  <IntOptions>None</IntOptions>
+  <CurrentProfile>Default</CurrentProfile>
+  <MainWindow>
+    <X>655</X>
+    <Y>405</Y>
+    <W>1250</W>
+    <H>600</H>
+    <State>Normal</State>
+  </MainWindow>
+</Settings>


### PR DESCRIPTION
This P.R. cleans up a bit and add a new option to reset 7TH Settings.xml file.

It creates the folder if it does not exist.
On a fresh install, the first time opening 7TH will prompt the user to the General Setting popup, here they will have to re-select FF7 Exe path with the same file - triggering the copying of the correct exe.