### PR TITLE
Fix modifying shortcut with multiple accounts

### DIFF
--- a/7HFix.sh
+++ b/7HFix.sh
@@ -114,10 +114,11 @@ cp -f "$FULL_PATH/Resources/FF7_1.02_Eng_Patch/ff7.exe" "$WINEPATH/drive_c/FF7/f
 echo "Done!"
 
 echo
-echo "Altering Steam shortcut..."
-SHORTCUTSFILE=$(ls -td ${HOME}/.steam/steam/userdata/* | head -1)/config/shortcuts.vdf
-sed -i "s:$(pwd)/${SEVENHEAVEN}:${FULL_PATH}/7th Heaven.exe:" $SHORTCUTSFILE
-sed -i "s:$(pwd):${FULL_PATH}:" $SHORTCUTSFILE
+echo "Altering Steam 7th Heaven shortcut for all Steam accounts..."
+for SHORTCUTSFILE in ${HOME}/.steam/steam/userdata/*/config/shortcuts.vdf ; do
+  sed -i "s:$(pwd)/${SEVENHEAVEN}:${FULL_PATH}/7th Heaven.exe:" $SHORTCUTSFILE
+  sed -i "s:$(pwd):${FULL_PATH}:" $SHORTCUTSFILE
+done
 echo "Done!"
 
 echo


### PR DESCRIPTION
Hello, thank you very much for the cool work!

Adding my contributions and a small fix for the bug I faced. I tested the script on my deck and this does solve my issue.

Updating shortcuts was failing when the Steam Deck had multiple accounts folders within `~/.steam/steam/userdata`, even though, in my particular case, only the main account had a `shortcuts.vdf`.

This commit just iterates over the potential files to do the operation.

It breaks one (unexpected and unhandled) behavior though: it will silently fail when the file does not exist (instead of outputting a `sed(1)` error and continuing).